### PR TITLE
feat: merge features from robotdad/amplifier-module-hooks-otel

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,239 @@
+# amplifier-module-hooks-otel Design
+
+## Overview
+
+OpenTelemetry instrumentation hook for Amplifier. Captures traces, span events, and metrics from Amplifier sessions for observability in APM tools like Jaeger, .NET Aspire, Grafana, and Honeycomb.
+
+This module follows Amplifier's kernel philosophy: **mechanism, not policy**. It provides the mechanism for telemetry export; applications decide where to send it.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Amplifier Session                         │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              Kernel Event System                     │    │
+│  │  (session:start, llm:request, tool:pre, etc.)       │    │
+│  └──────────────────────┬──────────────────────────────┘    │
+│                         │ events                             │
+│                         ▼                                    │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              hooks-otel Module                       │    │
+│  │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐    │    │
+│  │  │ SpanManager │ │  Metrics    │ │  Attribute  │    │    │
+│  │  │             │ │  Recorder   │ │   Mapper    │    │    │
+│  │  └──────┬──────┘ └──────┬──────┘ └─────────────┘    │    │
+│  └─────────┼───────────────┼───────────────────────────┘    │
+│            │               │                                 │
+└────────────┼───────────────┼────────────────────────────────┘
+             │               │
+             ▼               ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Exporters                                 │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐       │
+│  │ Console  │ │ OTLP-HTTP│ │ OTLP-gRPC│ │   File   │       │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘       │
+└─────────────────────────────────────────────────────────────┘
+             │               │
+             ▼               ▼
+┌─────────────────────────────────────────────────────────────┐
+│              APM Backends                                    │
+│  Jaeger, .NET Aspire, Grafana Tempo, Honeycomb, etc.        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Key Design Decisions
+
+### 1. W3C Trace Context Propagation
+
+**Problem**: Agent spawning (via task tool) creates child sessions. Without proper trace linking, these appear as disconnected traces in APM tools.
+
+**Solution**: Full W3C Trace Context propagation:
+- Child sessions inherit parent's `trace_id`
+- Child's `parent_id` points to parent session's `span_id`
+- Enables distributed tracing across agent hierarchies
+
+```
+Parent Session (trace_id=abc123)
+├── amplifier.session (span_id=001)
+│   └── amplifier.tool "task" (span_id=002)
+│       └── Child Session (trace_id=abc123, parent_id=002)
+│           └── amplifier.session (span_id=003)
+│               └── ... child's work ...
+```
+
+### 2. GenAI Semantic Conventions
+
+Follows OpenTelemetry GenAI semantic conventions for LLM observability:
+
+| Attribute | Description |
+|-----------|-------------|
+| `gen_ai.system` | Provider name (anthropic, openai) |
+| `gen_ai.request.model` | Model identifier |
+| `gen_ai.usage.input_tokens` | Input token count |
+| `gen_ai.usage.output_tokens` | Output token count |
+| `gen_ai.response.finish_reasons` | Completion reason |
+
+### 3. Nested Tool Stack
+
+**Problem**: Tools can call other tools (e.g., task tool spawns agents that use tools).
+
+**Solution**: Maintain a tool stack per session:
+```python
+# Tool A starts
+stack: [Tool A span]
+
+# Tool A calls Tool B (nested)
+stack: [Tool A span, Tool B span]
+
+# Tool B completes
+stack: [Tool A span]  # Restored
+
+# Tool A completes
+stack: []
+```
+
+### 4. Priority-Based Hook Registration
+
+**Problem**: Observability hooks should see events at the right time:
+- Start events: See initial state before business hooks modify data
+- End events: See final state after all processing
+
+**Solution**: Priority-based registration:
+| Event Type | Priority | Rationale |
+|------------|----------|-----------|
+| Start events (session:start, tool:pre) | Low (5) | Observe early |
+| End events (session:end, tool:post) | High (95) | Capture final state |
+| Instant events (artifact:write) | Medium (50) | Order doesn't matter |
+
+### 5. Multiple Exporter Support
+
+| Exporter | Use Case | Processor |
+|----------|----------|-----------|
+| `console` | Development, debugging | SimpleSpanProcessor |
+| `otlp-http` | Production (Jaeger, Aspire) | BatchSpanProcessor |
+| `otlp-grpc` | Production (high throughput) | BatchSpanProcessor |
+| `file` | Debugging, offline analysis | SimpleSpanProcessor |
+
+### 6. Opt-Out Mechanism
+
+Environment variable `AMPLIFIER_OTEL_OPT_OUT=true` disables all telemetry:
+- Checked at module load time
+- Overrides any config settings
+- Zero overhead when disabled (no spans created)
+
+## Span Hierarchy
+
+```
+amplifier.session (root, SpanKind.SERVER)
+├── amplifier.turn (per execution turn)
+│   ├── chat {model} (LLM call, SpanKind.CLIENT)
+│   ├── execute_tool {name} (tool execution)
+│   │   └── execute_tool {nested} (nested tools)
+│   ├── prompt (prompt processing)
+│   ├── plan (planning phase)
+│   └── approval_pending (human approval wait)
+├── context_compaction (instant event)
+├── artifact_write (instant event)
+└── policy_violation (instant event, ERROR status)
+```
+
+## Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `gen_ai.client.token.usage` | Counter | Token consumption by model/provider |
+| `gen_ai.client.operation.duration` | Histogram | LLM call latency |
+| `amplifier.tool.duration` | Histogram | Tool execution time |
+| `amplifier.session.duration` | Histogram | Session duration |
+
+## Configuration
+
+```yaml
+hooks:
+  - module: hooks-otel
+    config:
+      enabled: true
+      exporter: otlp-http          # console, otlp-http, otlp-grpc, file
+      endpoint: http://localhost:4318
+      service_name: my-amplifier-app
+      service_version: 1.0.0
+      user_id: ""                   # Falls back to $USER
+      team_id: ""                   # For team tracking in APM
+      sampling_rate: 1.0            # 1.0 = 100%, 0.1 = 10%
+      file_path: /tmp/traces.jsonl  # For file exporter
+      capture:
+        traces: true
+        metrics: true
+        span_events: true
+      max_attribute_length: 1000
+      batch_delay_ms: 5000
+      max_batch_size: 512
+      debug: false
+```
+
+## Event Coverage
+
+All kernel events are instrumented:
+
+| Category | Events |
+|----------|--------|
+| Session | session:start, session:end, session:fork, session:resume |
+| Execution | execution:start, execution:end, orchestrator:complete |
+| LLM | llm:request, llm:response, provider:error |
+| Tools | tool:pre, tool:post, tool:error |
+| Prompt | prompt:submit, prompt:complete |
+| Planning | plan:start, plan:end |
+| Context | context:compaction, context:include |
+| Approvals | approval:required, approval:granted, approval:denied |
+| Cancellation | cancel:requested, cancel:completed |
+| Artifacts | artifact:write, artifact:read |
+| Policy | policy:violation |
+
+## Integration Examples
+
+### .NET Aspire
+
+```yaml
+hooks:
+  - module: hooks-otel
+    config:
+      exporter: otlp-http
+      endpoint: http://localhost:18889  # Aspire dashboard
+```
+
+### Jaeger
+
+```yaml
+hooks:
+  - module: hooks-otel
+    config:
+      exporter: otlp-http
+      endpoint: http://localhost:4318
+```
+
+### Local Debugging
+
+```yaml
+hooks:
+  - module: hooks-otel
+    config:
+      exporter: file
+      file_path: ./traces.jsonl
+      debug: true
+```
+
+## Philosophy Alignment
+
+This module embodies Amplifier's kernel philosophy:
+
+1. **Mechanism, not policy**: Provides telemetry export mechanism; applications decide destination
+2. **Non-interference**: Always returns `HookResult(action="continue")`; never blocks or modifies events
+3. **Opt-out by default**: Can be disabled via environment variable
+4. **Observability as mechanism**: The kernel provides events; this module translates them to OTel
+
+## Credits
+
+This implementation merges work from:
+- **colombod/amplifier-module-hooks-otel**: W3C Trace Context, GenAI conventions, test suite
+- **robotdad/amplifier-module-hooks-otel**: Multiple exporters, nested tool stack, priority registration

--- a/amplifier_module_hooks_otel/config.py
+++ b/amplifier_module_hooks_otel/config.py
@@ -2,10 +2,13 @@
 
 import os
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 # Environment variable for global opt-out
 OPT_OUT_ENV_VAR = "AMPLIFIER_OTEL_OPT_OUT"
+
+# Supported exporter types
+ExporterType = Literal["console", "otlp-http", "otlp-grpc", "file"]
 
 
 def _check_opt_out() -> bool:
@@ -23,19 +26,82 @@ def _check_opt_out() -> bool:
 
 
 @dataclass
+class CaptureConfig:
+    """What telemetry signals to capture."""
+
+    traces: bool = True
+    metrics: bool = True
+    span_events: bool = True
+
+
+@dataclass
 class OTelConfig:
     """Configuration for OTel hook.
 
     Attributes:
         enabled: Master switch - if False, all telemetry is disabled.
             Also respects AMPLIFIER_OTEL_OPT_OUT environment variable.
-        traces_enabled: Whether to emit trace spans.
-        metrics_enabled: Whether to record metrics.
+        service_name: Service name in traces (default: "amplifier").
+        service_version: Service version (default: "0.1.0").
+        user_id: User identifier for team tracking (falls back to $USER).
+        team_id: Team identifier for grouping in APM dashboards.
+        exporter: Exporter type - "console", "otlp-http", "otlp-grpc", "file".
+        endpoint: OTLP endpoint URL (default: "http://localhost:4318").
+        headers: HTTP headers for OTLP (e.g., auth tokens).
+        file_path: Path for file exporter output.
+        sampling_rate: Sampling rate 0.0-1.0 (1.0 = 100%).
+        capture: What to capture (traces, metrics, span_events).
+        max_attribute_length: Max length for attribute values (truncates).
+        batch_delay_ms: Batch export delay in milliseconds.
+        max_batch_size: Maximum spans per batch.
+        debug: Enable debug output.
     """
 
+    # Master switch
     enabled: bool = field(default_factory=_check_opt_out)
-    traces_enabled: bool = True
-    metrics_enabled: bool = True
+
+    # Service identification
+    service_name: str = "amplifier"
+    service_version: str = "0.1.0"
+
+    # User/team identification (for team tracking)
+    user_id: str = ""  # Falls back to $USER if empty
+    team_id: str = ""  # Optional team grouping
+
+    # Exporter configuration
+    exporter: ExporterType = "console"
+    endpoint: str = "http://localhost:4318"  # OTLP HTTP default
+    headers: dict[str, str] = field(default_factory=dict)
+
+    # For file exporter
+    file_path: str = "/tmp/amplifier-traces.jsonl"
+
+    # Sampling (1.0 = 100%, 0.1 = 10%)
+    sampling_rate: float = 1.0
+
+    # What to capture
+    capture: CaptureConfig = field(default_factory=CaptureConfig)
+
+    # Attribute limits (prevent huge payloads)
+    max_attribute_length: int = 1000
+
+    # Batching configuration
+    batch_delay_ms: int = 5000
+    max_batch_size: int = 512
+
+    # Debug mode (verbose logging)
+    debug: bool = False
+
+    # Legacy compatibility aliases
+    @property
+    def traces_enabled(self) -> bool:
+        """Legacy alias for capture.traces."""
+        return self.capture.traces
+
+    @property
+    def metrics_enabled(self) -> bool:
+        """Legacy alias for capture.metrics."""
+        return self.capture.metrics
 
     @classmethod
     def from_dict(cls, config: dict[str, Any]) -> "OTelConfig":
@@ -50,17 +116,40 @@ class OTelConfig:
         Returns:
             OTelConfig instance with values from dict or defaults.
         """
+        # Handle nested capture config
+        capture_data = config.pop("capture", {})
+        if capture_data:
+            capture = CaptureConfig(**capture_data)
+        else:
+            # Legacy flat config support
+            capture = CaptureConfig(
+                traces=config.pop("traces_enabled", True),
+                metrics=config.pop("metrics_enabled", True),
+                span_events=config.pop("span_events_enabled", True),
+            )
+
         known_fields = {
             "enabled",
-            "traces_enabled",
-            "metrics_enabled",
+            "service_name",
+            "service_version",
+            "user_id",
+            "team_id",
+            "exporter",
+            "endpoint",
+            "headers",
+            "file_path",
+            "sampling_rate",
+            "max_attribute_length",
+            "batch_delay_ms",
+            "max_batch_size",
+            "debug",
         }
 
         # Extract only known fields
         filtered = {k: v for k, v in config.items() if k in known_fields}
 
-        # Create instance (enabled defaults to env var check)
-        instance = cls(**filtered)
+        # Create instance
+        instance = cls(capture=capture, **filtered)
 
         # If env var opts out, override config
         if not _check_opt_out():
@@ -75,4 +164,4 @@ class OTelConfig:
         Returns:
             True if enabled AND at least one of traces/metrics is enabled.
         """
-        return self.enabled and (self.traces_enabled or self.metrics_enabled)
+        return self.enabled and (self.capture.traces or self.capture.metrics)

--- a/amplifier_module_hooks_otel/exporters.py
+++ b/amplifier_module_hooks_otel/exporters.py
@@ -1,0 +1,207 @@
+"""Exporter configuration for OTel hook module.
+
+Supports multiple exporter backends:
+- console: Print spans to stdout (development)
+- otlp-http: Send to OTLP collector via HTTP (production)
+- otlp-grpc: Send to OTLP collector via gRPC (production)
+- file: Write spans to JSONL file (debugging)
+
+Based on robotdad/amplifier-module-hooks-otel exporters.py.
+"""
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+from opentelemetry import metrics, trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace import ReadableSpan
+
+from .config import OTelConfig
+
+
+class FileSpanExporter(SpanExporter):
+    """Simple file-based span exporter for debugging.
+
+    Writes spans as JSONL (one JSON object per line) for easy inspection.
+    """
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        # Ensure file exists
+        open(file_path, "a").close()
+
+    def export(self, spans: list["ReadableSpan"]) -> SpanExportResult:
+        """Export spans to file."""
+        try:
+            with open(self.file_path, "a") as f:
+                for span in spans:
+                    record = {
+                        "name": span.name,
+                        "trace_id": format(span.context.trace_id, "032x"),
+                        "span_id": format(span.context.span_id, "016x"),
+                        "parent_span_id": (
+                            format(span.parent.span_id, "016x") if span.parent else None
+                        ),
+                        "start_time": span.start_time,
+                        "end_time": span.end_time,
+                        "attributes": dict(span.attributes) if span.attributes else {},
+                        "status": span.status.status_code.name,
+                        "events": [
+                            {
+                                "name": e.name,
+                                "timestamp": e.timestamp,
+                                "attributes": dict(e.attributes) if e.attributes else {},
+                            }
+                            for e in span.events
+                        ],
+                    }
+                    f.write(json.dumps(record) + "\n")
+            return SpanExportResult.SUCCESS
+        except Exception:
+            return SpanExportResult.FAILURE
+
+    def shutdown(self) -> None:
+        """Shutdown the exporter."""
+        pass
+
+
+def _build_resource(config: OTelConfig) -> Resource:
+    """Build OTel resource with service and user attributes."""
+    return Resource.create(
+        {
+            "service.name": config.service_name,
+            "service.version": config.service_version,
+            "amplifier.user.id": config.user_id or os.environ.get("USER", "unknown"),
+            "amplifier.team.id": config.team_id,
+        }
+    )
+
+
+def setup_tracing(config: OTelConfig) -> None:
+    """Configure OpenTelemetry tracing with the specified exporter.
+
+    Args:
+        config: OTelConfig with exporter settings.
+
+    Raises:
+        ValueError: If exporter type is unknown.
+    """
+    resource = _build_resource(config)
+    provider = TracerProvider(resource=resource)
+
+    # Configure exporter based on config
+    if config.exporter == "console":
+        # Console exporter - immediate output, good for development
+        exporter = ConsoleSpanExporter()
+        processor = SimpleSpanProcessor(exporter)
+
+    elif config.exporter == "otlp-http":
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        exporter = OTLPSpanExporter(
+            endpoint=f"{config.endpoint}/v1/traces",
+            headers=config.headers or None,
+        )
+        processor = BatchSpanProcessor(
+            exporter,
+            max_queue_size=config.max_batch_size,
+            schedule_delay_millis=config.batch_delay_ms,
+        )
+
+    elif config.exporter == "otlp-grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+        exporter = OTLPSpanExporter(
+            endpoint=config.endpoint,
+            headers=config.headers or None,
+        )
+        processor = BatchSpanProcessor(
+            exporter,
+            max_queue_size=config.max_batch_size,
+            schedule_delay_millis=config.batch_delay_ms,
+        )
+
+    elif config.exporter == "file":
+        exporter = FileSpanExporter(config.file_path)
+        processor = SimpleSpanProcessor(exporter)
+
+    else:
+        raise ValueError(f"Unknown exporter type: {config.exporter}")
+
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+
+    if config.debug:
+        print(f"[otel] Configured {config.exporter} trace exporter")
+        if config.exporter in ("otlp-http", "otlp-grpc"):
+            print(f"[otel] Endpoint: {config.endpoint}")
+        elif config.exporter == "file":
+            print(f"[otel] File: {config.file_path}")
+
+
+def setup_metrics(config: OTelConfig) -> None:
+    """Configure OpenTelemetry metrics with the specified exporter.
+
+    Args:
+        config: OTelConfig with exporter settings.
+    """
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import (
+        ConsoleMetricExporter,
+        PeriodicExportingMetricReader,
+    )
+
+    resource = _build_resource(config)
+
+    if config.exporter == "console":
+        reader = PeriodicExportingMetricReader(
+            ConsoleMetricExporter(),
+            export_interval_millis=config.batch_delay_ms,
+        )
+    elif config.exporter in ("otlp-http", "otlp-grpc"):
+        if config.exporter == "otlp-http":
+            from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+                OTLPMetricExporter,
+            )
+
+            exporter = OTLPMetricExporter(
+                endpoint=f"{config.endpoint}/v1/metrics",
+                headers=config.headers or None,
+            )
+        else:
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+                OTLPMetricExporter,
+            )
+
+            exporter = OTLPMetricExporter(
+                endpoint=config.endpoint,
+                headers=config.headers or None,
+            )
+
+        reader = PeriodicExportingMetricReader(
+            exporter,
+            export_interval_millis=config.batch_delay_ms,
+        )
+    else:
+        # File exporter doesn't support metrics yet, use console
+        reader = PeriodicExportingMetricReader(
+            ConsoleMetricExporter(),
+            export_interval_millis=config.batch_delay_ms,
+        )
+
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+
+    if config.debug:
+        print(f"[otel] Configured {config.exporter} metrics exporter")

--- a/amplifier_module_hooks_otel/spans.py
+++ b/amplifier_module_hooks_otel/spans.py
@@ -1,12 +1,33 @@
-"""Span lifecycle management for OpenTelemetry tracing."""
+"""Span lifecycle management for OpenTelemetry tracing.
+
+Based on colombod's W3C Trace Context implementation with nested tool stack
+from robotdad/amplifier-module-hooks-otel.
+"""
 
 import logging
+from dataclasses import dataclass, field
 from typing import Any
 
 from opentelemetry import trace
 from opentelemetry.trace import Span, SpanKind, StatusCode, Tracer
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionSpanContext:
+    """Tracks spans for a single session.
+
+    Supports nested tool execution (e.g., task tool spawning child agents)
+    via a tool stack.
+    """
+
+    session_id: str
+    root_span: Span | None = None
+    current_turn: Span | None = None
+    current_tool: Span | None = None
+    tool_stack: list[Span] = field(default_factory=list)  # For nested tools
+    turn_count: int = 0
 
 
 class SpanManager:
@@ -19,6 +40,9 @@ class SpanManager:
 
     Spans are correlated using session_id and correlation_key for matching
     start/end events.
+
+    Supports nested tool execution via tool_stack for scenarios like
+    the task tool spawning child agent sessions.
     """
 
     def __init__(self, tracer: Tracer) -> None:
@@ -28,10 +52,17 @@ class SpanManager:
             tracer: OpenTelemetry Tracer instance.
         """
         self._tracer = tracer
-        self._session_spans: dict[str, Span] = {}  # session_id → root span
-        self._turn_spans: dict[str, Span] = {}  # session_id → current turn span
+        self._sessions: dict[str, SessionSpanContext] = {}
+        self._session_spans: dict[str, Span] = {}  # Legacy: session_id → root span
+        self._turn_spans: dict[str, Span] = {}  # Legacy: session_id → current turn span
         self._active_spans: dict[str, Span] = {}  # correlation_key → span
-        self._turn_counters: dict[str, int] = {}  # session_id → turn number
+        self._turn_counters: dict[str, int] = {}  # Legacy: session_id → turn number
+
+    def _get_context(self, session_id: str) -> SessionSpanContext:
+        """Get or create span context for session."""
+        if session_id not in self._sessions:
+            self._sessions[session_id] = SessionSpanContext(session_id=session_id)
+        return self._sessions[session_id]
 
     def start_session_span(
         self,
@@ -55,15 +86,19 @@ class SpanManager:
         Returns:
             The created session span.
         """
-        context = None
+        ctx = self._get_context(session_id)
+        trace_context = None
 
         # If this is a child session, link to parent's span for trace continuity
         if parent_session_id:
-            parent_span = self._session_spans.get(parent_session_id)
+            parent_ctx = self._sessions.get(parent_session_id)
+            parent_span = parent_ctx.root_span if parent_ctx else self._session_spans.get(
+                parent_session_id
+            )
             if parent_span:
                 # Create context with parent span - this propagates trace_id
                 # and sets parent_id to the parent span's span_id
-                context = trace.set_span_in_context(parent_span)
+                trace_context = trace.set_span_in_context(parent_span)
                 logger.debug(f"Linking child session {session_id} to parent {parent_session_id}")
             else:
                 logger.warning(
@@ -75,10 +110,15 @@ class SpanManager:
             "amplifier.session",
             kind=SpanKind.SERVER,
             attributes=attributes,
-            context=context,
+            context=trace_context,
         )
+        ctx.root_span = span
+        ctx.turn_count = 0
+
+        # Legacy support
         self._session_spans[session_id] = span
         self._turn_counters[session_id] = 0
+
         logger.debug(f"Started session span for {session_id}")
         return span
 
@@ -94,22 +134,49 @@ class SpanManager:
         Returns:
             The SpanContext if the session span exists, None otherwise.
         """
+        ctx = self._sessions.get(session_id)
+        if ctx and ctx.root_span:
+            return ctx.root_span.get_span_context()
+        # Legacy fallback
         if span := self._session_spans.get(session_id):
             return span.get_span_context()
         return None
 
-    def end_session_span(self, session_id: str) -> None:
+    def end_session_span(self, session_id: str, status: str = "completed", error: str | None = None) -> None:
         """End session span.
 
         Args:
             session_id: The session identifier.
+            status: Session completion status.
+            error: Optional error message.
         """
-        if span := self._session_spans.pop(session_id, None):
-            span.end()
+        ctx = self._sessions.pop(session_id, None)
+        if ctx:
+            if ctx.root_span:
+                ctx.root_span.set_attribute("session.status", status)
+                ctx.root_span.set_attribute("session.turns", ctx.turn_count)
+                if error:
+                    ctx.root_span.set_status(StatusCode.ERROR, error)
+                else:
+                    ctx.root_span.set_status(StatusCode.OK)
+                ctx.root_span.end()
+            # Clean up any remaining turn span
+            if ctx.current_turn:
+                ctx.current_turn.end()
+            # Clean up any remaining tool spans
+            for tool_span in ctx.tool_stack:
+                tool_span.end()
+            if ctx.current_tool:
+                ctx.current_tool.end()
             logger.debug(f"Ended session span for {session_id}")
-        # Cleanup turn span if exists
+
+        # Legacy cleanup
+        if span := self._session_spans.pop(session_id, None):
+            if not ctx:  # Only end if not already ended above
+                span.end()
         if span := self._turn_spans.pop(session_id, None):
-            span.end()
+            if not ctx:
+                span.end()
         self._turn_counters.pop(session_id, None)
 
     def start_turn_span(self, session_id: str) -> Span | None:
@@ -121,28 +188,33 @@ class SpanManager:
         Returns:
             The created turn span, or None if no session span exists.
         """
-        parent_span = self._session_spans.get(session_id)
+        ctx = self._get_context(session_id)
+        parent_span = ctx.root_span or self._session_spans.get(session_id)
         if not parent_span:
             logger.warning(f"No session span for turn: {session_id}")
             return None
 
         # End previous turn span if exists
+        if ctx.current_turn:
+            ctx.current_turn.end()
         if old_turn := self._turn_spans.get(session_id):
-            old_turn.end()
+            if old_turn != ctx.current_turn:
+                old_turn.end()
 
         # Increment turn counter
-        self._turn_counters[session_id] = self._turn_counters.get(session_id, 0) + 1
-        turn_number = self._turn_counters[session_id]
+        ctx.turn_count += 1
+        self._turn_counters[session_id] = ctx.turn_count
 
         # Start new turn span as child of session span
         with trace.use_span(parent_span, end_on_exit=False):
             span = self._tracer.start_span(
                 "amplifier.turn",
                 kind=SpanKind.INTERNAL,
-                attributes={"amplifier.turn.number": turn_number},
+                attributes={"amplifier.turn.number": ctx.turn_count},
             )
+        ctx.current_turn = span
         self._turn_spans[session_id] = span
-        logger.debug(f"Started turn {turn_number} span for {session_id}")
+        logger.debug(f"Started turn {ctx.turn_count} span for {session_id}")
         return span
 
     def end_turn_span(self, session_id: str) -> None:
@@ -151,9 +223,130 @@ class SpanManager:
         Args:
             session_id: The session identifier.
         """
-        if span := self._turn_spans.pop(session_id, None):
-            span.end()
+        ctx = self._sessions.get(session_id)
+        if ctx and ctx.current_turn:
+            ctx.current_turn.end()
+            ctx.current_turn = None
             logger.debug(f"Ended turn span for {session_id}")
+
+        # Legacy cleanup
+        if span := self._turn_spans.pop(session_id, None):
+            if not ctx or span != ctx.current_turn:
+                pass  # Already ended above or different span
+
+    def start_tool_span(
+        self,
+        session_id: str,
+        tool_name: str,
+        tool_input: dict | None = None,
+        correlation_key: str | None = None,
+        max_attribute_length: int = 1000,
+    ) -> Span | None:
+        """Start a span for tool execution with nested tool support.
+
+        Supports nested tools (e.g., task tool calling another tool) by
+        maintaining a tool stack per session.
+
+        Args:
+            session_id: The session identifier.
+            tool_name: Name of the tool being executed.
+            tool_input: Optional tool input data.
+            correlation_key: Optional key for later retrieval/ending.
+            max_attribute_length: Max length for attribute values.
+
+        Returns:
+            The created tool span, or None if no parent span exists.
+        """
+        ctx = self._get_context(session_id)
+
+        # Parent is current tool (nested), turn, or session
+        parent = ctx.current_tool or ctx.current_turn or ctx.root_span
+        if not parent:
+            # Legacy fallback
+            parent = self._turn_spans.get(session_id) or self._session_spans.get(session_id)
+        if not parent:
+            logger.warning(f"No parent span for tool: {session_id}")
+            return None
+
+        # Push current tool onto stack before creating new one (for nesting)
+        if ctx.current_tool:
+            ctx.tool_stack.append(ctx.current_tool)
+
+        # Truncate tool input if needed
+        input_str = ""
+        if tool_input:
+            input_str = str(tool_input)
+            if len(input_str) > max_attribute_length:
+                input_str = input_str[:max_attribute_length] + "...[truncated]"
+
+        with trace.use_span(parent, end_on_exit=False):
+            span = self._tracer.start_span(
+                "amplifier.tool",
+                kind=SpanKind.INTERNAL,
+                attributes={
+                    "tool.name": tool_name,
+                    "tool.input": input_str,
+                },
+            )
+
+        ctx.current_tool = span
+        if correlation_key:
+            self._active_spans[correlation_key] = span
+
+        logger.debug(f"Started tool span '{tool_name}' for {session_id} (stack depth: {len(ctx.tool_stack)})")
+        return span
+
+    def end_tool_span(
+        self,
+        session_id: str,
+        tool_name: str,
+        correlation_key: str | None = None,
+        success: bool = True,
+        result: Any = None,
+        error: str | None = None,
+        max_attribute_length: int = 1000,
+    ) -> None:
+        """End current tool span with nested tool support.
+
+        Args:
+            session_id: The session identifier.
+            tool_name: Name of the tool (for logging).
+            correlation_key: Optional key used when starting.
+            success: Whether tool execution succeeded.
+            result: Optional tool result.
+            error: Optional error message.
+            max_attribute_length: Max length for attribute values.
+        """
+        ctx = self._sessions.get(session_id)
+        span = None
+
+        # Try correlation key first, then current tool
+        if correlation_key:
+            span = self._active_spans.pop(correlation_key, None)
+        if not span and ctx:
+            span = ctx.current_tool
+
+        if span:
+            span.set_attribute("tool.success", success)
+
+            if result is not None:
+                result_str = str(result)
+                if len(result_str) > max_attribute_length:
+                    result_str = result_str[:max_attribute_length] + "...[truncated]"
+                span.set_attribute("tool.result", result_str)
+
+            if error:
+                span.set_status(StatusCode.ERROR, error)
+            else:
+                span.set_status(StatusCode.OK)
+
+            span.end()
+
+            # Pop previous tool from stack (restore parent tool context)
+            if ctx:
+                ctx.current_tool = ctx.tool_stack.pop() if ctx.tool_stack else None
+
+            logger.debug(f"Ended tool span '{tool_name}' for {session_id}")
 
     def start_child_span(
         self,
@@ -175,8 +368,15 @@ class SpanManager:
         Returns:
             The created child span, or None if no parent span exists.
         """
+        ctx = self._sessions.get(session_id)
+
         # Try turn span first, fall back to session span
-        parent = self._turn_spans.get(session_id) or self._session_spans.get(session_id)
+        parent = None
+        if ctx:
+            parent = ctx.current_turn or ctx.root_span
+        if not parent:
+            parent = self._turn_spans.get(session_id) or self._session_spans.get(session_id)
+
         if not parent:
             logger.warning(f"No parent span for child: {session_id}")
             return None
@@ -220,3 +420,37 @@ class SpanManager:
             The span if found, None otherwise.
         """
         return self._active_spans.get(correlation_key)
+
+    def add_event(
+        self,
+        session_id: str,
+        event_name: str,
+        attributes: dict[str, Any] | None = None,
+        span_type: str = "current",
+    ) -> None:
+        """Add an event to the appropriate span.
+
+        Args:
+            session_id: The session identifier.
+            event_name: Name of the event.
+            attributes: Optional event attributes.
+            span_type: Which span to add to: "current", "tool", "turn", "session".
+        """
+        ctx = self._sessions.get(session_id)
+        if not ctx:
+            return
+
+        # Select target span
+        span = None
+        if span_type == "tool" and ctx.current_tool:
+            span = ctx.current_tool
+        elif span_type == "turn" and ctx.current_turn:
+            span = ctx.current_turn
+        elif span_type == "session" and ctx.root_span:
+            span = ctx.root_span
+        else:
+            # "current" - pick most specific active span
+            span = ctx.current_tool or ctx.current_turn or ctx.root_span
+
+        if span:
+            span.add_event(event_name, attributes=attributes or {})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,244 @@
+"""Tests for OTelConfig and configuration handling."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from amplifier_module_hooks_otel.config import (
+    OPT_OUT_ENV_VAR,
+    CaptureConfig,
+    OTelConfig,
+    _check_opt_out,
+)
+
+
+class TestOptOut:
+    """Tests for opt-out functionality."""
+
+    def test_opt_out_not_set(self):
+        """When env var is not set, telemetry should be enabled."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove the env var if it exists
+            os.environ.pop(OPT_OUT_ENV_VAR, None)
+            assert _check_opt_out() is True
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "Yes", "ON"])
+    def test_opt_out_truthy_values(self, value: str):
+        """Truthy values should disable telemetry."""
+        with patch.dict(os.environ, {OPT_OUT_ENV_VAR: value}):
+            assert _check_opt_out() is False
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "other"])
+    def test_opt_out_falsy_values(self, value: str):
+        """Non-truthy values should keep telemetry enabled."""
+        with patch.dict(os.environ, {OPT_OUT_ENV_VAR: value}):
+            assert _check_opt_out() is True
+
+
+class TestCaptureConfig:
+    """Tests for CaptureConfig."""
+
+    def test_defaults(self):
+        """Default values should enable all capture."""
+        config = CaptureConfig()
+        assert config.traces is True
+        assert config.metrics is True
+        assert config.span_events is True
+
+    def test_custom_values(self):
+        """Should accept custom values."""
+        config = CaptureConfig(traces=False, metrics=True, span_events=False)
+        assert config.traces is False
+        assert config.metrics is True
+        assert config.span_events is False
+
+
+class TestOTelConfig:
+    """Tests for OTelConfig."""
+
+    def test_defaults(self):
+        """Default configuration values."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop(OPT_OUT_ENV_VAR, None)
+            config = OTelConfig()
+
+            assert config.enabled is True
+            assert config.service_name == "amplifier"
+            assert config.service_version == "0.1.0"
+            assert config.exporter == "console"
+            assert config.endpoint == "http://localhost:4318"
+            assert config.sampling_rate == 1.0
+            assert config.capture.traces is True
+            assert config.capture.metrics is True
+
+    def test_exporter_types(self):
+        """Should accept valid exporter types."""
+        for exporter in ["console", "otlp-http", "otlp-grpc", "file"]:
+            config = OTelConfig(exporter=exporter)  # type: ignore
+            assert config.exporter == exporter
+
+    def test_sampling_rate(self):
+        """Should accept sampling rate values."""
+        config = OTelConfig(sampling_rate=0.5)
+        assert config.sampling_rate == 0.5
+
+        config = OTelConfig(sampling_rate=0.0)
+        assert config.sampling_rate == 0.0
+
+        config = OTelConfig(sampling_rate=1.0)
+        assert config.sampling_rate == 1.0
+
+    def test_team_and_user_tracking(self):
+        """Should support team and user tracking."""
+        config = OTelConfig(user_id="test-user", team_id="test-team")
+        assert config.user_id == "test-user"
+        assert config.team_id == "test-team"
+
+    def test_batch_config(self):
+        """Should support batch configuration."""
+        config = OTelConfig(batch_delay_ms=10000, max_batch_size=1024)
+        assert config.batch_delay_ms == 10000
+        assert config.max_batch_size == 1024
+
+    def test_file_path(self):
+        """Should support file path for file exporter."""
+        config = OTelConfig(exporter="file", file_path="/custom/path.jsonl")  # type: ignore
+        assert config.file_path == "/custom/path.jsonl"
+
+    def test_headers(self):
+        """Should support custom headers for OTLP."""
+        headers = {"Authorization": "Bearer token123"}
+        config = OTelConfig(headers=headers)
+        assert config.headers == headers
+
+    def test_legacy_aliases(self):
+        """Legacy aliases should work."""
+        config = OTelConfig()
+        config.capture.traces = False
+        config.capture.metrics = True
+
+        assert config.traces_enabled is False
+        assert config.metrics_enabled is True
+
+    def test_is_active_when_enabled(self):
+        """is_active should be True when enabled and traces/metrics on."""
+        config = OTelConfig(enabled=True)
+        config.capture.traces = True
+        assert config.is_active is True
+
+    def test_is_active_when_disabled(self):
+        """is_active should be False when disabled."""
+        config = OTelConfig(enabled=False)
+        assert config.is_active is False
+
+    def test_is_active_when_no_signals(self):
+        """is_active should be False when no signals enabled."""
+        config = OTelConfig(enabled=True)
+        config.capture.traces = False
+        config.capture.metrics = False
+        assert config.is_active is False
+
+
+class TestOTelConfigFromDict:
+    """Tests for OTelConfig.from_dict()."""
+
+    def test_empty_dict(self):
+        """Empty dict should use defaults."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop(OPT_OUT_ENV_VAR, None)
+            config = OTelConfig.from_dict({})
+            assert config.enabled is True
+            assert config.exporter == "console"
+
+    def test_basic_fields(self):
+        """Should parse basic fields."""
+        config = OTelConfig.from_dict(
+            {
+                "enabled": True,
+                "exporter": "otlp-http",
+                "endpoint": "http://jaeger:4318",
+                "service_name": "my-app",
+            }
+        )
+        assert config.exporter == "otlp-http"
+        assert config.endpoint == "http://jaeger:4318"
+        assert config.service_name == "my-app"
+
+    def test_nested_capture_config(self):
+        """Should parse nested capture config."""
+        config = OTelConfig.from_dict(
+            {
+                "capture": {
+                    "traces": True,
+                    "metrics": False,
+                    "span_events": True,
+                }
+            }
+        )
+        assert config.capture.traces is True
+        assert config.capture.metrics is False
+        assert config.capture.span_events is True
+
+    def test_legacy_flat_config(self):
+        """Should support legacy flat config (traces_enabled, metrics_enabled)."""
+        config = OTelConfig.from_dict(
+            {
+                "traces_enabled": False,
+                "metrics_enabled": True,
+            }
+        )
+        assert config.capture.traces is False
+        assert config.capture.metrics is True
+
+    def test_unknown_fields_ignored(self):
+        """Unknown fields should be ignored."""
+        config = OTelConfig.from_dict(
+            {
+                "enabled": True,
+                "unknown_field": "value",
+                "another_unknown": 123,
+            }
+        )
+        assert config.enabled is True
+        assert not hasattr(config, "unknown_field")
+
+    def test_env_var_overrides_config(self):
+        """Environment variable should override config."""
+        with patch.dict(os.environ, {OPT_OUT_ENV_VAR: "1"}):
+            config = OTelConfig.from_dict({"enabled": True})
+            assert config.enabled is False
+
+    def test_all_fields(self):
+        """Should parse all supported fields."""
+        config = OTelConfig.from_dict(
+            {
+                "enabled": True,
+                "service_name": "test-service",
+                "service_version": "2.0.0",
+                "user_id": "user123",
+                "team_id": "team456",
+                "exporter": "otlp-grpc",
+                "endpoint": "http://collector:4317",
+                "headers": {"X-Custom": "value"},
+                "file_path": "/logs/traces.jsonl",
+                "sampling_rate": 0.5,
+                "max_attribute_length": 2000,
+                "batch_delay_ms": 10000,
+                "max_batch_size": 256,
+                "debug": True,
+            }
+        )
+        assert config.service_name == "test-service"
+        assert config.service_version == "2.0.0"
+        assert config.user_id == "user123"
+        assert config.team_id == "team456"
+        assert config.exporter == "otlp-grpc"
+        assert config.endpoint == "http://collector:4317"
+        assert config.headers == {"X-Custom": "value"}
+        assert config.file_path == "/logs/traces.jsonl"
+        assert config.sampling_rate == 0.5
+        assert config.max_attribute_length == 2000
+        assert config.batch_delay_ms == 10000
+        assert config.max_batch_size == 256
+        assert config.debug is True

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,166 @@
+"""Tests for exporters module."""
+
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from amplifier_module_hooks_otel.config import OTelConfig
+from amplifier_module_hooks_otel.exporters import (
+    FileSpanExporter,
+    _build_resource,
+    setup_tracing,
+)
+
+
+class TestBuildResource:
+    """Tests for _build_resource."""
+
+    def test_basic_resource(self):
+        """Should create resource with service name and version."""
+        config = OTelConfig(service_name="test-app", service_version="1.0.0")
+        resource = _build_resource(config)
+
+        attrs = dict(resource.attributes)
+        assert attrs["service.name"] == "test-app"
+        assert attrs["service.version"] == "1.0.0"
+
+    def test_user_id_from_config(self):
+        """Should use user_id from config."""
+        config = OTelConfig(user_id="custom-user")
+        resource = _build_resource(config)
+
+        attrs = dict(resource.attributes)
+        assert attrs["amplifier.user.id"] == "custom-user"
+
+    def test_user_id_fallback_to_env(self):
+        """Should fall back to USER env var when user_id is empty."""
+        with patch.dict(os.environ, {"USER": "env-user"}):
+            config = OTelConfig(user_id="")
+            resource = _build_resource(config)
+
+            attrs = dict(resource.attributes)
+            assert attrs["amplifier.user.id"] == "env-user"
+
+    def test_team_id(self):
+        """Should include team_id."""
+        config = OTelConfig(team_id="my-team")
+        resource = _build_resource(config)
+
+        attrs = dict(resource.attributes)
+        assert attrs["amplifier.team.id"] == "my-team"
+
+
+class TestFileSpanExporter:
+    """Tests for FileSpanExporter."""
+
+    def test_creates_file(self):
+        """Should create file if it doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "traces.jsonl")
+            exporter = FileSpanExporter(file_path)
+            assert os.path.exists(file_path)
+            exporter.shutdown()
+
+    def test_exports_spans(self):
+        """Should write spans as JSONL."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "traces.jsonl")
+            exporter = FileSpanExporter(file_path)
+
+            # Create mock span
+            mock_span = MagicMock()
+            mock_span.name = "test-span"
+            mock_span.context.trace_id = 0x12345678901234567890123456789012
+            mock_span.context.span_id = 0x1234567890123456
+            mock_span.parent = None
+            mock_span.start_time = 1000000000
+            mock_span.end_time = 2000000000
+            mock_span.attributes = {"key": "value"}
+            mock_span.status.status_code.name = "OK"
+            mock_span.events = []
+
+            # Export
+            from opentelemetry.sdk.trace.export import SpanExportResult
+
+            result = exporter.export([mock_span])
+            assert result == SpanExportResult.SUCCESS
+
+            # Verify file content
+            with open(file_path) as f:
+                line = f.readline()
+                record = json.loads(line)
+                assert record["name"] == "test-span"
+                assert record["attributes"] == {"key": "value"}
+                assert record["status"] == "OK"
+
+            exporter.shutdown()
+
+    def test_handles_events(self):
+        """Should include span events."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "traces.jsonl")
+            exporter = FileSpanExporter(file_path)
+
+            # Create mock event
+            mock_event = MagicMock()
+            mock_event.name = "test-event"
+            mock_event.timestamp = 1500000000
+            mock_event.attributes = {"event_key": "event_value"}
+
+            # Create mock span with event
+            mock_span = MagicMock()
+            mock_span.name = "test-span"
+            mock_span.context.trace_id = 0x12345678901234567890123456789012
+            mock_span.context.span_id = 0x1234567890123456
+            mock_span.parent = None
+            mock_span.start_time = 1000000000
+            mock_span.end_time = 2000000000
+            mock_span.attributes = {}
+            mock_span.status.status_code.name = "OK"
+            mock_span.events = [mock_event]
+
+            exporter.export([mock_span])
+
+            with open(file_path) as f:
+                record = json.loads(f.readline())
+                assert len(record["events"]) == 1
+                assert record["events"][0]["name"] == "test-event"
+
+            exporter.shutdown()
+
+
+class TestSetupTracing:
+    """Tests for setup_tracing."""
+
+    def test_console_exporter(self):
+        """Should set up console exporter without error."""
+        config = OTelConfig(exporter="console")  # type: ignore
+        # Should not raise
+        setup_tracing(config)
+
+    def test_file_exporter(self):
+        """Should set up file exporter without error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "traces.jsonl")
+            config = OTelConfig(exporter="file", file_path=file_path)  # type: ignore
+            setup_tracing(config)
+            assert os.path.exists(file_path)
+
+    def test_unknown_exporter_raises(self):
+        """Should raise ValueError for unknown exporter."""
+        config = OTelConfig()
+        config.exporter = "unknown"  # type: ignore
+        with pytest.raises(ValueError, match="Unknown exporter type"):
+            setup_tracing(config)
+
+    def test_debug_output(self, capsys):
+        """Should print debug info when debug=True."""
+        config = OTelConfig(exporter="console", debug=True)  # type: ignore
+        setup_tracing(config)
+
+        captured = capsys.readouterr()
+        assert "[otel]" in captured.out
+        assert "console" in captured.out

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -17,14 +17,14 @@ def hook():
 @pytest.fixture
 def hook_no_metrics():
     """Create an OTelHook with metrics disabled."""
-    config = OTelConfig(metrics_enabled=False)
+    config = OTelConfig.from_dict({"capture": {"traces": True, "metrics": False}})
     return OTelHook(config)
 
 
 @pytest.fixture
 def hook_no_traces():
     """Create an OTelHook with traces disabled."""
-    config = OTelConfig(traces_enabled=False)
+    config = OTelConfig.from_dict({"capture": {"traces": False, "metrics": True}})
     return OTelHook(config)
 
 
@@ -388,15 +388,21 @@ class TestOTelConfig:
     def test_is_active_property(self):
         """is_active returns True only when enabled AND features active."""
         # Fully enabled
-        config = OTelConfig(enabled=True, traces_enabled=True, metrics_enabled=True)
+        config = OTelConfig.from_dict(
+            {"enabled": True, "capture": {"traces": True, "metrics": True}}
+        )
         assert config.is_active is True
 
         # Disabled globally
-        config = OTelConfig(enabled=False, traces_enabled=True, metrics_enabled=True)
+        config = OTelConfig.from_dict(
+            {"enabled": False, "capture": {"traces": True, "metrics": True}}
+        )
         assert config.is_active is False
 
         # Enabled but no features
-        config = OTelConfig(enabled=True, traces_enabled=False, metrics_enabled=False)
+        config = OTelConfig.from_dict(
+            {"enabled": True, "capture": {"traces": False, "metrics": False}}
+        )
         assert config.is_active is False
 
 


### PR DESCRIPTION
## Summary

This PR merges the best features from [robotdad/amplifier-module-hooks-otel](https://github.com/robotdad/amplifier-module-hooks-otel) while preserving our core strengths (W3C Trace Context, GenAI conventions, comprehensive tests).

## Features Merged from robotdad

- **Multiple exporters**: `console`, `otlp-http`, `otlp-grpc`, `file`
- **FileSpanExporter**: Write spans to JSONL for debugging
- **Priority-based hook registration**: Low priority (5) for start events, high priority (95) for end events
- **Nested tool stack**: Support for task tool spawning child agents
- **Extended configuration**: `sampling_rate`, `team_id`, batch settings
- **DESIGN.md**: Architecture documentation

## Preserved from colombod

- ✅ **W3C Trace Context propagation** - Same `trace_id` across agent spawns (critical for .NET Aspire)
- ✅ **GenAI semantic conventions** - Proper `gen_ai.*` attribute names
- ✅ **Comprehensive test suite** - Now 127 tests (was 82)
- ✅ **Opt-out mechanism** - `AMPLIFIER_OTEL_OPT_OUT` environment variable

## New Configuration Options

```yaml
hooks:
  - module: hooks-otel
    config:
      exporter: otlp-http          # console, otlp-http, otlp-grpc, file
      endpoint: http://localhost:4318
      sampling_rate: 1.0           # 0.0-1.0 (1.0 = 100%)
      team_id: my-team             # Team tracking in APM
      file_path: ./traces.jsonl    # For file exporter
      batch_delay_ms: 5000
      max_batch_size: 512
```

## Files Changed

| File | Changes |
|------|---------|
| `config.py` | Extended with new options (exporter, sampling, team_id, batch) |
| `exporters.py` | **NEW** - Multiple exporter support + FileSpanExporter |
| `spans.py` | Added nested tool stack, add_event() method |
| `__init__.py` | Priority-based registration, automatic exporter setup |
| `DESIGN.md` | **NEW** - Architecture documentation |
| `README.md` | Updated with new features and examples |
| `tests/test_config.py` | **NEW** - Config tests (34 tests) |
| `tests/test_exporters.py` | **NEW** - Exporter tests (11 tests) |

## Testing

All 127 tests pass:
```
============================= 127 passed in 0.18s ==============================
```

## Credits

This implementation merges work from:
- **colombod**: W3C Trace Context, GenAI conventions, test suite
- **robotdad** (@robotdad): Multiple exporters, nested tool stack, priority registration

Closes #1